### PR TITLE
a fix for "GOBANG for windows"

### DIFF
--- a/GOBANG/GOBANG for Windows/GOBANG.cpp
+++ b/GOBANG/GOBANG for Windows/GOBANG.cpp
@@ -395,6 +395,7 @@ int judge()
 	{
 		return 4;
 	}
+	return 0;
 }
 
 void tip()


### PR DESCRIPTION
When compiling, there is a warning: "GOBANG.CPP:398:1: warning: control reaches end of non-void function [-Wreturn-typ.e]".
To solve it, we can add "return 0;" in Line 398. 